### PR TITLE
Anchors for `define`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,13 @@ All notable changes to the "mkdocs-plugin-rzk" plugin will be documented in this
 
 Check [Keep a Changelog](https://keepachangelog.com/) for recommendations on how to structure this file.
 
-## Unreleased
+## v0.1.3 - 2023.09.04
 
 ### Added
 
 - Transform all `#define`d names to anchors to their respective positions.
 
-## 0.1.2
+## v0.1.2
 
 Initial release of the rzk MkDocs plugin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to the "mkdocs-plugin-rzk" plugin will be documented in this file.
+
+Check [Keep a Changelog](https://keepachangelog.com/) for recommendations on how to structure this file.
+
+## Unreleased
+
+### Added
+
+- Transform all `#define`d names to anchors to their respective positions.
+
+## 0.1.2
+
+Initial release of the rzk MkDocs plugin
+
+### Added
+
+- Insert SVG renderings next to their definitions

--- a/README.md
+++ b/README.md
@@ -11,9 +11,11 @@ plugins:
 
 The following config options are supported:
 
-| Name | Type  | Default | Description                |
-| ---- | ----- | ------- | -------------------------- |
-| path | `str` | `rzk`   | Path to the Rzk executable |
+| Name               | Type   | Default | Description                                     |
+| ------------------ | ------ | ------- | ----------------------------------------------- |
+| path               | `str`  | `rzk`   | Path to the Rzk executable                      |
+| render_svg         | `bool` | `True`  | Enable/disable rendering SVGs for definitions (currently only works for files without dependencies) |
+| anchor_definitions | `bool` | `True`  | Turn names of definitions into links to themselves (useful for generating a link to a particular `#define` in the generated MkDocs) |
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -6,3 +6,23 @@ This is a [MkDocs plugin](https://www.mkdocs.org/dev-guide/plugins) for renderin
 plugins:
   - rzk
 ```
+
+## Configuration
+
+The following config options are supported:
+
+| Name | Type  | Default | Description                |
+| ---- | ----- | ------- | -------------------------- |
+| path | `str` | `rzk`   | Path to the Rzk executable |
+
+## Development
+
+To test this plugin while developing locally, run `pip install --editable <path/to/this/folder>` in the MkDocs project where this plugin is to be used. You will need to manually stop and rerun the MkDocs server on every update (hot reloading does not work).
+
+## Packaging and Deployment
+
+If you don't have them already, install the `build` and `twine` packages as such: `python3 -m pip install --upgrade build twine`.
+
+Next, package your code by running `python3 -m build` to generate distribution archives (wheels) under the `dist` directory.
+
+Lastly, run `twine upload dist/*` to upload the new version to PyPI.

--- a/rzk/generate_svgs.py
+++ b/rzk/generate_svgs.py
@@ -14,7 +14,8 @@ logger = logging.getLogger('mkdocs')
 
 class RzkPluginConfig(base.Config):
     path = c.Type(str, default='rzk')
-
+    render_svg = c.Type(bool, default=True)
+    anchor_definitions = c.Type(bool, default=True)
 
 class RzkPlugin(BasePlugin[RzkPluginConfig]):
     def __init__(self):
@@ -33,6 +34,7 @@ class RzkPlugin(BasePlugin[RzkPluginConfig]):
             self.rzk_installed = False
 
     def on_page_markdown(self, md: str, page: Page, config: MkDocsConfig, files: Files) -> str:
+        if not self.config.render_svg: return md
         if not page.file.src_uri.endswith('.rzk.md'): return md
         if not self.rzk_installed: return md
         logger.info('Inserting SVG diagrams in ' + page.file.src_uri)
@@ -60,10 +62,11 @@ class RzkPlugin(BasePlugin[RzkPluginConfig]):
 
         return md
 
-    def on_page_content(self, html: str, *, page: Page, config: MkDocsConfig, files: Files) -> str | None:
+    def on_page_content(self, html: str, *, page: Page, config: MkDocsConfig, files: Files) -> str:
+        if not self.config.anchor_definitions: return html
         defines = self.define_name.findall(html)
         for (span, name) in defines:
-            a = f'<a href="#define-{name}" id="define-{name}" style="visibility: visible; position: relative; color: inherit">{name}</a>'
+            a = f'<a href="#define:{name}" id="define:{name}" style="visibility: visible; position: relative; color: inherit">{name}</a>'
             span_with_link = span.replace(name, a)
             html = html.replace(span, span_with_link)
         return html

--- a/rzk/generate_svgs.py
+++ b/rzk/generate_svgs.py
@@ -19,6 +19,7 @@ class RzkPluginConfig(base.Config):
 class RzkPlugin(BasePlugin[RzkPluginConfig]):
     def __init__(self):
         self.rzk_code_block = re.compile(r'(^```\s*rzk[^\n]*\s+(.*?)\s+^```)', flags=re.MULTILINE | re.DOTALL)
+        self.define_name = re.compile(r'(<span class="nf">(.*?)</span>)')
         self.svg_element = re.compile(r'^(<svg.*?</svg>)', flags=re.MULTILINE | re.DOTALL)
         self.rzk_installed = True
 
@@ -58,3 +59,11 @@ class RzkPlugin(BasePlugin[RzkPluginConfig]):
                 md = md.replace(fenced_block, svg + '\n\n' + fenced_block)
 
         return md
+
+    def on_page_content(self, html: str, *, page: Page, config: MkDocsConfig, files: Files) -> str | None:
+        defines = self.define_name.findall(html)
+        for (span, name) in defines:
+            a = f'<a href="#define-{name}" id="define-{name}" style="visibility: visible; position: relative; color: inherit">{name}</a>'
+            span_with_link = span.replace(name, a)
+            html = html.replace(span, span_with_link)
+        return html

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
     license='MIT',
     project_urls={
         'Source': 'https://github.com/rzk-lang/mkdocs-plugin-rzk',
+        'Release notes': 'https://github.com/rzk-lang/mkdocs-plugin-rzk/blob/master/CHANGELOG.md',
         'Tracker': 'https://github.com/rzk-lang/mkdocs-plugin-rzk/issues',
     },
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,10 @@ setup(
     author='Abdelrahman Abounegm',
     author_email='a.abounegm@innopolis.university',
     license='MIT',
+    project_urls={
+        'Source': 'https://github.com/rzk-lang/mkdocs-plugin-rzk',
+        'Tracker': 'https://github.com/rzk-lang/mkdocs-plugin-rzk/issues',
+    },
     install_requires=[
         'mkdocs>=1.4.0'
     ],

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='mkdocs-plugin-rzk',
-    version='0.1.2',
+    version='0.1.3',
     description='A MkDocs plugin for Literate Rzk',
     long_description='This plugin automates the generation of SVG renderings for code snippets in Literate Rzk Markdown files rendered using MkDocs.',
     keywords='mkdocs',


### PR DESCRIPTION
Replace all `#define`d identifiers with anchors.